### PR TITLE
chore: updated gitlab template using extends key

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -29,7 +29,7 @@ install:
     - npm run cy:verify
 
 # all jobs that actually run tests can use the same definition
-.job_template: &job
+.job_template:
   image: cypress/base:10
   stage: test
   script:
@@ -43,12 +43,12 @@ install:
 # actual job definitions
 # all steps are the same, they come from the template above
 electrons-1:
-  <<: *job
+  extends: .job_template
 electrons-2:
-  <<: *job
+  extends: .job_template
 electrons-3:
-  <<: *job
+  extends: .job_template
 electrons-4:
-  <<: *job
+  extends: .job_template
 electrons-5:
-  <<: *job
+  extends: .job_template


### PR DESCRIPTION
Gitlab added `extends` job key, which is easier to understand and read then YAML anchors.

https://docs.gitlab.com/ee/ci/yaml/#extends